### PR TITLE
add reference to PRs in Open MPI GitHub repository in patches for OpenMPI 4.1.1

### DIFF
--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-11.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1-GCC-11.2.0.eb
@@ -20,8 +20,8 @@ checksums = [
     'a189d834506f3d7c31eda6aa184598a3631ea24a94bc551d5ed1f053772ca49e',
     # OpenMPI-4.0.6_remove-pmix-check-in-pmi-switch.patch
     '8acee6c9b2b4bf12873a39b85a58ca669de78e90d26186e52f221bb4853abc4d',
-    'a85b09da354916c2a08c24922268e4f25352daf2787c7c90cd5d24ca4f8d892f',  # OpenMPI-4.1.1_opal-pmix-package-rank.patch
-    'cd250609f2c7974774a4e8931873bc795c0769581f91530524df516490de4954',  # OpenMPI-4.1.1_pmix3x-protection.patch
+    '04353672cf7be031e5306c94068d7012d99e6cd94b69d93230797ffcd7f31903',  # OpenMPI-4.1.1_opal-pmix-package-rank.patch
+    '384ef9f1fa803b0d71dae2ec0748d0f20295992437532afedf21478bda164ff8',  # OpenMPI-4.1.1_pmix3x-protection.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1_opal-pmix-package-rank.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1_opal-pmix-package-rank.patch
@@ -1,3 +1,5 @@
+see https://github.com/open-mpi/ompi/pull/9212
+
 From 8b07775d1002cc9be887c41768aea9ac896c5ecd Mon Sep 17 00:00:00 2001
 From: Ralph Castain <rhc@pmix.org>
 Date: Tue, 10 Aug 2021 08:38:15 -0700

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1_pmix3x-protection.patch
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.1.1_pmix3x-protection.patch
@@ -1,3 +1,5 @@
+see https://github.com/open-mpi/ompi/pull/9213
+
 From bd48a06e25c1058b7d3c3ba4414af388836c8219 Mon Sep 17 00:00:00 2001
 From: Ralph Castain <rhc@pmix.org>
 Date: Tue, 10 Aug 2021 13:01:11 -0700


### PR DESCRIPTION
@Micket for https://github.com/easybuilders/easybuild-easyconfigs/pull/13668

We should probably also add these patches to `OpenMPI-4.1.1-GCC-10.3.0.eb`?