### PR TITLE
add patch for Qt5-5.15.2-GCCcore-11.2.0.eb

### DIFF
--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2-GCCcore-11.2.0.eb
@@ -38,7 +38,8 @@ builddependencies = [
     ('flex', '2.6.4'),
     ('gperf', '3.1'),
     ('Ninja', '1.10.2'),
-    ('Python', '3.9.6', '-bare'),
+    # Qt5WebEngine has build dependency on Python 2
+    ('Python', '2.7.18', '-bare'),
     ('re2c', '2.2'),
 ]
 

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2-GCCcore-11.2.0.eb
@@ -20,12 +20,14 @@ patches = [
     'Qt5-5.13.1_fix-avx2.patch',
     'Qt5-5.13.1_fix-qmake-libdir.patch',
     'Qt5-5.14.1_fix-OF-Gentoo.patch',
+    'Qt5-5.15.2_fix-gcc11.patch',
 ]
 checksums = [
     '3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240',  # qt-everywhere-src-5.15.2.tar.xz
     '6f46005f056bf9e6ff3e5d012a874d18ee03b33e685941f2979c970be91a9dbc',  # Qt5-5.13.1_fix-avx2.patch
     '511ca9c0599ceb1989f73d8ceea9199c041512d3a26ee8c5fd870ead2c10cb63',  # Qt5-5.13.1_fix-qmake-libdir.patch
     '0b9defb7ce75314d85bebe07e143db7f7de316fec64c17cbd13f7eec5d2d1afa',  # Qt5-5.14.1_fix-OF-Gentoo.patch
+    '6606e2434aacaac49545be733bf012f1d489393bf8bd5573691c171ab8bc0976',  # Qt5-5.15.2_fix-gcc11.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2_fix-gcc11.patch
+++ b/easybuild/easyconfigs/q/Qt5/Qt5-5.15.2_fix-gcc11.patch
@@ -1,0 +1,139 @@
+# Qt 5.15.2 build fixes for GCC 11
+#
+# Upstream patches:
+#   https://code.qt.io/cgit/qt/qtbase.git/commit/?id=813a928c7c3cf986
+#   https://code.qt.io/cgit/qt/qtbase.git/commit/?id=9c56d4da2ff631a8
+#   https://code.qt.io/cgit/qt/qtdeclarative.git/commit/?id=367293b18ab0d0a0
+#
+# Third-party software patches (taken from Fedora):
+#   https://src.fedoraproject.org/rpms/qt5-qtwebengine/blob/rawhide/f/qtwebengine-gcc11.patch
+#
+diff -Nrup a/qtbase/src/corelib/global/qendian.h b/qtbase/src/corelib/global/qendian.h
+--- a/qtbase/src/corelib/global/qendian.h	2020-10-27 09:02:11.000000000 +0100
++++ b/qtbase/src/corelib/global/qendian.h	2021-06-21 18:02:01.741899258 +0200
+@@ -1,7 +1,7 @@
+ /****************************************************************************
+ **
+-** Copyright (C) 2016 The Qt Company Ltd.
+-** Copyright (C) 2016 Intel Corporation.
++** Copyright (C) 2021 The Qt Company Ltd.
++** Copyright (C) 2021 Intel Corporation.
+ ** Contact: https://www.qt.io/licensing/
+ **
+ ** This file is part of the QtCore module of the Qt Toolkit.
+@@ -44,6 +44,8 @@
+ #include <QtCore/qfloat16.h>
+ #include <QtCore/qglobal.h>
+ 
++#include <limits>
++
+ // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
+ #include <stdlib.h>
+ #include <string.h>
+diff -Nrup a/qtbase/src/corelib/global/qfloat16.h b/qtbase/src/corelib/global/qfloat16.h
+--- a/qtbase/src/corelib/global/qfloat16.h	2020-10-27 09:02:11.000000000 +0100
++++ b/qtbase/src/corelib/global/qfloat16.h	2021-06-21 18:02:17.409709370 +0200
+@@ -43,6 +43,7 @@
+ 
+ #include <QtCore/qglobal.h>
+ #include <QtCore/qmetatype.h>
++#include <limits>
+ #include <string.h>
+ 
+ #if defined(QT_COMPILER_SUPPORTS_F16C) && defined(__AVX2__) && !defined(__F16C__)
+diff -Nrup a/qtbase/src/corelib/text/qbytearraymatcher.h b/qtbase/src/corelib/text/qbytearraymatcher.h
+--- a/qtbase/src/corelib/text/qbytearraymatcher.h	2020-10-27 09:02:11.000000000 +0100
++++ b/qtbase/src/corelib/text/qbytearraymatcher.h	2021-06-21 18:13:45.885352546 +0200
+@@ -42,6 +42,8 @@
+ 
+ #include <QtCore/qbytearray.h>
+ 
++#include <limits>
++
+ QT_BEGIN_NAMESPACE
+ 
+ 
+diff -Nrup a/qtbase/src/corelib/tools/qsharedpointer_impl.h b/qtbase/src/corelib/tools/qsharedpointer_impl.h
+--- a/qtbase/src/corelib/tools/qsharedpointer_impl.h	2020-10-27 09:02:11.000000000 +0100
++++ b/qtbase/src/corelib/tools/qsharedpointer_impl.h	2021-06-21 18:13:45.885352546 +0200
+@@ -155,9 +155,6 @@ namespace QtSharedPointer {
+ #endif
+         inline void checkQObjectShared(...) { }
+         inline void setQObjectShared(...) { }
+-
+-        inline void operator delete(void *ptr) { ::operator delete(ptr); }
+-        inline void operator delete(void *, void *) { }
+     };
+     // sizeof(ExternalRefCountData) = 12 (32-bit) / 16 (64-bit)
+ 
+diff -Nrup a/qtbase/src/plugins/platforms/xcb/qxcbwindow.cpp b/qtbase/src/plugins/platforms/xcb/qxcbwindow.cpp
+--- a/qtbase/src/plugins/platforms/xcb/qxcbwindow.cpp	2020-10-27 09:02:11.000000000 +0100
++++ b/qtbase/src/plugins/platforms/xcb/qxcbwindow.cpp	2021-06-21 18:13:45.885352546 +0200
+@@ -698,7 +698,7 @@ void QXcbWindow::show()
+         if (isTransient(window())) {
+             const QWindow *tp = window()->transientParent();
+             if (tp && tp->handle())
+-                transientXcbParent = static_cast<const QXcbWindow *>(tp->handle())->winId();
++                transientXcbParent = tp->handle()->winId();
+             // Default to client leader if there is no transient parent, else modal dialogs can
+             // be hidden by their parents.
+             if (!transientXcbParent)
+diff -Nrup a/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h b/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h
+--- a/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h	2020-10-27 09:02:12.000000000 +0100
++++ b/qtdeclarative/src/qmldebug/qqmlprofilerevent_p.h	2021-06-22 09:35:22.877912946 +0200
+@@ -48,6 +48,7 @@
+ #include <QtCore/qmetatype.h>
+ 
+ #include <initializer_list>
++#include <limits>
+ #include <type_traits>
+ 
+ //
+diff -Nrup a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.cc b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.cc	2020-11-07 02:22:36.000000000 +0100
++++ b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.cc	2021-06-22 12:05:40.736177321 +0200
+@@ -14,9 +14,9 @@
+  * limitations under the License.
+  */
+ 
++#include <limits>
+ #include "src/trace_processor/containers/string_pool.h"
+ 
+-#include <limits>
+ 
+ #include "perfetto/base/logging.h"
+ #include "perfetto/ext/base/utils.h"
+diff -Nrup a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/db/column.cc b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/db/column.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/db/column.cc	2020-11-07 02:22:36.000000000 +0100
++++ b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/db/column.cc	2021-06-22 12:06:05.087880649 +0200
+@@ -14,6 +14,7 @@
+  * limitations under the License.
+  */
+ 
++#include <limits>
+ #include "src/trace_processor/db/column.h"
+ 
+ #include "src/trace_processor/db/compare.h"
+diff -Nrup a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/importers/proto/heap_graph_walker.cc b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/importers/proto/heap_graph_walker.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/importers/proto/heap_graph_walker.cc	2020-11-07 02:22:36.000000000 +0100
++++ b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/importers/proto/heap_graph_walker.cc	2021-06-22 12:06:28.911590412 +0200
+@@ -14,6 +14,8 @@
+  * limitations under the License.
+  */
+ 
++#include <cstddef>
++
+ #include "src/trace_processor/importers/proto/heap_graph_walker.h"
+ #include "perfetto/base/logging.h"
+ 
+diff -Nrup a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc
+--- a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc	2020-11-07 02:22:36.000000000 +0100
++++ b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc	2021-06-22 12:06:52.631301445 +0200
+@@ -14,6 +14,7 @@
+  * limitations under the License.
+  */
+ 
++#include <limits>
+ #include "src/trace_processor/types/variadic.h"
+ 
+ namespace perfetto {


### PR DESCRIPTION
This PR adds a patch from a college from mine for Qt5 with GCC 11. Building works. On my virtual machine however I still get `Sanity check failed: no file found at 'lib/libQt5WebEngine.so'`. But this could be related to a different issue.