### PR TITLE
add missing patches to OpenBLAS 0.3.20 with NVHPC/22.7 + retain -fb versionsuffix for ScalaPACK on top of FlexiBLAS

### DIFF
--- a/easybuild/easyconfigs/n/nvofbf/nvofbf-2022.07.eb
+++ b/easybuild/easyconfigs/n/nvofbf/nvofbf-2022.07.eb
@@ -19,7 +19,7 @@ dependencies = [
     ('FlexiBLAS', '3.2.0', '', local_compiler),
     ('FFTW', '3.3.10', '', local_compiler),
     ('FFTW.MPI', '3.3.10', '', local_comp_mpi_tc),
-    ('ScaLAPACK', '2.2.0', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.2.0', '-fb', local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.20-NVHPC-22.7-CUDA-11.7.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.20-NVHPC-22.7-CUDA-11.7.0.eb
@@ -16,13 +16,21 @@ patches = [
     ('large.tgz', '.'),
     ('timing.tgz', '.'),
     'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
+    'OpenBLAS-0.3.21_fix-order-vectorization.patch',
+    'OpenBLAS-0.3.21_disable-fma-in-cscal-zscal.patch',
+    'OpenBLAS-0.3.21_avoid-crash-in-zdot.patch',
 ]
 checksums = [
-    '8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c',  # v0.3.20.tar.gz
-    'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1',  # large.tgz
-    '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af',  # timing.tgz
-    # OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch
-    'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971',
+    {'v0.3.20.tar.gz': '8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c'},
+    {'large.tgz': 'f328d88b7fa97722f271d7d0cfea1c220e0f8e5ed5ff01d8ef1eb51d6f4243a1'},
+    {'timing.tgz': '999c65f8ea8bd4eac7f1c7f3463d4946917afd20a997807300fe35d70122f3af'},
+    {'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch':
+     'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
+    {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
+     '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
+    {'OpenBLAS-0.3.21_disable-fma-in-cscal-zscal.patch':
+     'bd6836206a883208dc8bc997946f97e4c97d91d8e101fc54db414aaa56902fc3'},
+    {'OpenBLAS-0.3.21_avoid-crash-in-zdot.patch': '3dac2c1ec896df574f1b37cde81a16f24550b7f1eb81fbfacb0c4449b0dc7894'},
 ]
 
 # extensive testing can be enabled by uncommenting the line below

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-nvompi-2022.07-fb.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.2.0-nvompi-2022.07-fb.eb
@@ -1,5 +1,6 @@
 name = 'ScaLAPACK'
 version = '2.2.0'
+versionsuffix = '-fb'
 
 homepage = 'https://www.netlib.org/scalapack/'
 description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines


### PR DESCRIPTION
@Micket for https://github.com/easybuilders/easybuild-easyconfigs/pull/16724