### PR TITLE
specify checksums for X11 20230603 in 'components'

### DIFF
--- a/easybuild/easyconfigs/x/X11/X11-20230603-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/x/X11/X11-20230603-GCCcore-12.3.0.eb
@@ -46,119 +46,162 @@ default_component_specs = {
 }
 
 components = [
-    ('libpthread-stubs', '0.4'),  # 2017-03-14
-    ('xorgproto', '2022.2'),  # 2022-08-11
-    ('libXau', '1.0.11'),  # 2022-12-08
-    ('libXdmcp', '1.1.4'),  # 2022-11-19
-    ('xcb-proto', '1.15.2'),  # 2022-06-17
-    ('libxcb', '1.15'),  # 2022-05-03
-    ('xtrans', '1.5.0'),  # 2023-06-03
+    ('libpthread-stubs', '0.4', {  # 2017-03-14
+        'checksums': ['50d5686b79019ccea08bcbd7b02fe5a40634abcfd4146b6e75c6420cc170e9d9'],
+    }),
+    ('xorgproto', '2022.2', {  # 2022-08-11
+        'checksums': ['da351a403d07a7006d7bdc8dcfc14ddc1b588b38fb81adab9989a8eef605757b'],
+    }),
+    ('libXau', '1.0.11', {  # 2022-12-08
+        'checksums': ['3a321aaceb803577a4776a5efe78836eb095a9e44bbc7a465d29463e1a14f189'],
+    }),
+    ('libXdmcp', '1.1.4', {  # 2022-11-19
+        'checksums': ['55041a8ff8992ab02777478c4b19c249c0f8399f05a752cb4a1a868a9a0ccb9a'],
+    }),
+    ('xcb-proto', '1.15.2', {  # 2022-06-17
+        'checksums': ['6b1ed9cd7cf35e37913eeecca37e5b85b14903002942b3e332f321335c27a8eb'],
+    }),
+    ('libxcb', '1.15', {  # 2022-05-03
+        'checksums': ['1cb65df8543a69ec0555ac696123ee386321dfac1964a3da39976c9a05ad724d'],
+    }),
+    ('xtrans', '1.5.0', {  # 2023-06-03
+        'checksums': ['a806f8a92f879dcd0146f3f1153fdffe845f2fc0df9b1a26c19312b7b0a29c86'],
+    }),
     ('libxkbcommon', '1.5.0', {  # 2023-01-02
         'easyblock': 'MesonNinja',
         'sources': [SOURCE_TAR_XZ],
+        'checksums': ['560f11c4bbbca10f495f3ef7d3a6aa4ca62b4f8fb0b52e7d459d18a26e46e017'],
         'preconfigopts': '',
         'configopts': '-Denable-wayland=false -Denable-docs=false ',
     }),
-    ('libX11', '1.8.5'),  # 2023-06-01
-    ('libXext', '1.3.5'),  # 2022-10-29
-    ('libFS', '1.0.9'),  # 2022-08-26
-    ('libICE', '1.1.1'),  # 2022-12-08
-    ('libSM', '1.2.4'),  # 2022-12-20
-    ('libXScrnSaver', '1.2.4'),  # 2022-12-05
-    ('libXt', '1.3.0'),  # 2023-05-09
-    ('libXmu', '1.1.4'),  # 2022-10-17
-    ('libXpm', '3.5.16'),  # 2023-04-17
-    ('libXaw', '1.0.15'),  # 2023-03-16
-    ('libXfixes', '6.0.1'),  # 2023-04-09
-    ('libXcomposite', '0.4.6'),  # 2022-12-04
-    ('libXrender', '0.9.11'),  # 2022-10-22
-    ('libXcursor', '1.2.1'),  # 2022-04-03
-    ('libXdamage', '1.1.6'),  # 2022-12-04
-    ('libfontenc', '1.1.7'),  # 2022-12-08
-    ('libXfont', '1.5.4'),  # 2017-11-28
-    ('libXfont2', '2.0.6'),  # 2022-08-26
-    ('libXft', '2.3.8'),  # 2023-04-17
-    ('libXi', '1.8.1'),  # 2023-05-04
-    ('libXinerama', '1.1.5'),  # 2022-10-29
-    ('libXrandr', '1.5.3'),  # 2022-11-20
-    ('libXres', '1.2.2'),  # 2022-12-05
-    ('libXtst', '1.2.4'),  # 2022-09-27
-    ('libXv', '1.0.12'),  # 2022-12-05
-    ('libXvMC', '1.0.13'),  # 2022-03-22
-    ('libXxf86dga', '1.1.6'),  # 2022-12-05
-    ('libXxf86vm', '1.1.5'),  # 2022-09-27
-    ('libdmx', '1.1.5'),  # 2023-06-03
-    ('libxkbfile', '1.1.2'),  # 2022-12-08
-    ('libxshmfence', '1.3.2'),  # 2022-12-08
-    ('xcb-util', '0.4.0'),  # 2014-10-15
-    ('xcb-util-image', '0.4.1'),  # 2022-10-18
-    ('xcb-util-keysyms', '0.4.1'),  # 2022-10-19
-    ('xcb-util-renderutil', '0.3.10'),  # 2022-10-19
-    ('xcb-util-wm', '0.4.2'),  # 2022-10-19
-    ('xcb-util-cursor', '0.1.4'),  # 2022-10-18
+    ('libX11', '1.8.5', {  # 2023-06-01
+        'checksums': ['d84a35c324d5a1724692eafc1ed76f1689c833021e0062933773ec437f91a56b'],
+    }),
+    ('libXext', '1.3.5', {  # 2022-10-29
+        'checksums': ['1a3dcda154f803be0285b46c9338515804b874b5ccc7a2b769ab7fd76f1035bd'],
+    }),
+    ('libFS', '1.0.9', {  # 2022-08-26
+        'checksums': ['8bc2762f63178905228a28670539badcfa2c8793f7b6ce3f597b7741b932054a'],
+    }),
+    ('libICE', '1.1.1', {  # 2022-12-08
+        'checksums': ['04fbd34a11ba08b9df2e3cdb2055c2e3c1c51b3257f683d7fcf42dabcf8e1210'],
+    }),
+    ('libSM', '1.2.4', {  # 2022-12-20
+        'checksums': ['51464ce1abce323d5b6707ceecf8468617106e1a8a98522f8342db06fd024c15'],
+    }),
+    ('libXScrnSaver', '1.2.4', {  # 2022-12-05
+        'checksums': ['0656b2630475104d6df75d91ebb8e0153e61d14e9871ef1f403bcda4a62a838a'],
+    }),
+    ('libXt', '1.3.0', {  # 2023-05-09
+        'checksums': ['de4a80c4cc7785b9620e572de71026805f68e85a2bf16c386009ef0e50be3f77'],
+    }),
+    ('libXmu', '1.1.4', {  # 2022-10-17
+        'checksums': ['3091d711cdc1d8ea0f545a13b90d1464c3c3ab64778fd121f0d789b277a80289'],
+    }),
+    ('libXpm', '3.5.16', {  # 2023-04-17
+        'checksums': ['43a70e6f9b67215fb223ca270d83bdcb868c513948441d5b781ea0765df6bfb4'],
+    }),
+    ('libXaw', '1.0.15', {  # 2023-03-16
+        'checksums': ['ca8a613884c922985202075b3cc8ee8821bfa83a5eb066189ae3cca131e63972'],
+    }),
+    ('libXfixes', '6.0.1', {  # 2023-04-09
+        'checksums': ['e69eaa321173c748ba6e2f15c7cf8da87f911d3ea1b6af4b547974aef6366bec'],
+    }),
+    ('libXcomposite', '0.4.6', {  # 2022-12-04
+        'checksums': ['3599dfcd96cd48d45e6aeb08578aa27636fa903f480f880c863622c2b352d076'],
+    }),
+    ('libXrender', '0.9.11', {  # 2022-10-22
+        'checksums': ['6aec3ca02e4273a8cbabf811ff22106f641438eb194a12c0ae93c7e08474b667'],
+    }),
+    ('libXcursor', '1.2.1', {  # 2022-04-03
+        'checksums': ['77f96b9ad0a3c422cfa826afabaf1e02b9bfbfc8908c5fa1a45094faad074b98'],
+    }),
+    ('libXdamage', '1.1.6', {  # 2022-12-04
+        'checksums': ['2afcc139eb6eb926ffe344494b1fc023da25def42874496e6e6d3aa8acef8595'],
+    }),
+    ('libfontenc', '1.1.7', {  # 2022-12-08
+        'checksums': ['5e5f210329823f08f97bfe9fd5b4105070c789bc5aef88ce01d86d8203d4aa9f'],
+    }),
+    ('libXfont', '1.5.4', {  # 2017-11-28
+        'checksums': ['59be6eab53f7b0feb6b7933c11d67d076ae2c0fd8921229c703fc7a4e9a80d6e'],
+    }),
+    ('libXfont2', '2.0.6', {  # 2022-08-26
+        'checksums': ['a944df7b6837c8fa2067f6a5fc25d89b0acc4011cd0bc085106a03557fb502fc'],
+    }),
+    ('libXft', '2.3.8', {  # 2023-04-17
+        'checksums': ['32e48fe2d844422e64809e4e99b9d8aed26c1b541a5acf837c5037b8d9f278a8'],
+    }),
+    ('libXi', '1.8.1', {  # 2023-05-04
+        'checksums': ['3b5f47c223e4b63d7f7fe758886b8bf665b20a7edb6962c423892fd150e326ea'],
+    }),
+    ('libXinerama', '1.1.5', {  # 2022-10-29
+        'checksums': ['2efa855cb42dc620eff3b77700d8655695e09aaa318f791f201fa60afa72b95c'],
+    }),
+    ('libXrandr', '1.5.3', {  # 2022-11-20
+        'checksums': ['3ad316c1781fe2fe22574b819e81f0eff087a8560377f521ba932238b41b251f'],
+    }),
+    ('libXres', '1.2.2', {  # 2022-12-05
+        'checksums': ['8abce597ced4a7ab89032aee91f6f784d9960adc772b2b59f17e515cd4127950'],
+    }),
+    ('libXtst', '1.2.4', {  # 2022-09-27
+        'checksums': ['01366506aeb033f6dffca5326af85f670746b0cabbfd092aabefb046cf48c445'],
+    }),
+    ('libXv', '1.0.12', {  # 2022-12-05
+        'checksums': ['ce706619a970a580a0e35e9b5c98bdd2af243ac6494c65f44608a89a86100126'],
+    }),
+    ('libXvMC', '1.0.13', {  # 2022-03-22
+        'checksums': ['e630b4373af8c67a7c8f07ebe626a1269a613d262d1f737b57231a06f7c34b4e'],
+    }),
+    ('libXxf86dga', '1.1.6', {  # 2022-12-05
+        'checksums': ['87c7482b1e29b4eeb415815641c4f69c00545a8138e1b73ff1f361f7d9c22ac4'],
+    }),
+    ('libXxf86vm', '1.1.5', {  # 2022-09-27
+        'checksums': ['f3f1c29fef8accb0adbd854900c03c6c42f1804f2bc1e4f3ad7b2e1f3b878128'],
+    }),
+    ('libdmx', '1.1.5', {  # 2023-06-03
+        'checksums': ['070e82cc1daa1b21ee1339aef56a909eab04cbe7d430fabfbb01ecd21b2dd9f3'],
+    }),
+    ('libxkbfile', '1.1.2', {  # 2022-12-08
+        'checksums': ['d1a7e659bc7ae1aa1fc1ecced261c734df5ad5d86af1ef7a946be0e2d841e51d'],
+    }),
+    ('libxshmfence', '1.3.2', {  # 2022-12-08
+        'checksums': ['e93a85099604beb244ee756dcaf70e18b08701c1ca84c4de0126cd71bd6c8181'],
+    }),
+    ('xcb-util', '0.4.0', {  # 2014-10-15
+        'checksums': ['0ed0934e2ef4ddff53fcc70fc64fb16fe766cd41ee00330312e20a985fd927a7'],
+    }),
+    ('xcb-util-image', '0.4.1', {  # 2022-10-18
+        'checksums': ['0ebd4cf809043fdeb4f980d58cdcf2b527035018924f8c14da76d1c81001293b'],
+    }),
+    ('xcb-util-keysyms', '0.4.1', {  # 2022-10-19
+        'checksums': ['1fa21c0cea3060caee7612b6577c1730da470b88cbdf846fa4e3e0ff78948e54'],
+    }),
+    ('xcb-util-renderutil', '0.3.10', {  # 2022-10-19
+        'checksums': ['e04143c48e1644c5e074243fa293d88f99005b3c50d1d54358954404e635128a'],
+    }),
+    ('xcb-util-wm', '0.4.2', {  # 2022-10-19
+        'checksums': ['dcecaaa535802fd57c84cceeff50c64efe7f2326bf752e16d2b77945649c8cd7'],
+    }),
+    ('xcb-util-cursor', '0.1.4', {  # 2022-10-18
+        'checksums': ['cc8608ebb695742b6cf84712be29b2b66aa5f6768039528794fca0fa283022bf'],
+    }),
     ('xkeyboard-config', '2.38', {  # 2022-02-04
         'easyblock': 'MesonNinja',
         'sources': [SOURCE_TAR_XZ],
+        'checksums': ['0690a91bab86b18868f3eee6d41e9ec4ce6894f655443d490a2184bfac56c872'],
         # required to overrule parent preconfigopts that runs autogen.sh if configure script is missing
         'preconfigopts': '',
     }),
-    ('printproto', '1.0.5'),  # 2011-01-06
-    ('libXp', '1.0.4'),  # 2022-09-12
-    ('xbitmaps', '1.1.3'), # 2023-02-23
+    ('printproto', '1.0.5', {  # 2011-01-06
+        'checksums': ['e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'],
+    }),
+    ('libXp', '1.0.4', {  # 2022-09-12
+        'checksums': ['05e46af1ccb68f1752cca5879774a4fb9bf3b19fe088eb745034956e0c6fadba'],
+    }),
+    ('xbitmaps', '1.1.3', {  # 2023-02-23
+        'checksums': ['93b433b7ff223c4685fdba583b4bd30f2706be2413a670021084422d85b0269d'],
+    }),
 ]
-
-checksums = [
-    {'libpthread-stubs-0.4.tar.gz': '50d5686b79019ccea08bcbd7b02fe5a40634abcfd4146b6e75c6420cc170e9d9'},
-    {'xorgproto-2022.2.tar.gz': 'da351a403d07a7006d7bdc8dcfc14ddc1b588b38fb81adab9989a8eef605757b'},
-    {'libXau-1.0.11.tar.gz': '3a321aaceb803577a4776a5efe78836eb095a9e44bbc7a465d29463e1a14f189'},
-    {'libXdmcp-1.1.4.tar.gz': '55041a8ff8992ab02777478c4b19c249c0f8399f05a752cb4a1a868a9a0ccb9a'},
-    {'xcb-proto-1.15.2.tar.gz': '6b1ed9cd7cf35e37913eeecca37e5b85b14903002942b3e332f321335c27a8eb'},
-    {'libxcb-1.15.tar.gz': '1cb65df8543a69ec0555ac696123ee386321dfac1964a3da39976c9a05ad724d'},
-    {'xtrans-1.5.0.tar.gz': 'a806f8a92f879dcd0146f3f1153fdffe845f2fc0df9b1a26c19312b7b0a29c86'},
-    {'libxkbcommon-1.5.0.tar.xz': '560f11c4bbbca10f495f3ef7d3a6aa4ca62b4f8fb0b52e7d459d18a26e46e017'},
-    {'libX11-1.8.5.tar.gz': 'd84a35c324d5a1724692eafc1ed76f1689c833021e0062933773ec437f91a56b'},
-    {'libXext-1.3.5.tar.gz': '1a3dcda154f803be0285b46c9338515804b874b5ccc7a2b769ab7fd76f1035bd'},
-    {'libFS-1.0.9.tar.gz': '8bc2762f63178905228a28670539badcfa2c8793f7b6ce3f597b7741b932054a'},
-    {'libICE-1.1.1.tar.gz': '04fbd34a11ba08b9df2e3cdb2055c2e3c1c51b3257f683d7fcf42dabcf8e1210'},
-    {'libSM-1.2.4.tar.gz': '51464ce1abce323d5b6707ceecf8468617106e1a8a98522f8342db06fd024c15'},
-    {'libXScrnSaver-1.2.4.tar.gz': '0656b2630475104d6df75d91ebb8e0153e61d14e9871ef1f403bcda4a62a838a'},
-    {'libXt-1.3.0.tar.gz': 'de4a80c4cc7785b9620e572de71026805f68e85a2bf16c386009ef0e50be3f77'},
-    {'libXmu-1.1.4.tar.gz': '3091d711cdc1d8ea0f545a13b90d1464c3c3ab64778fd121f0d789b277a80289'},
-    {'libXpm-3.5.16.tar.gz': '43a70e6f9b67215fb223ca270d83bdcb868c513948441d5b781ea0765df6bfb4'},
-    {'libXaw-1.0.15.tar.gz': 'ca8a613884c922985202075b3cc8ee8821bfa83a5eb066189ae3cca131e63972'},
-    {'libXfixes-6.0.1.tar.gz': 'e69eaa321173c748ba6e2f15c7cf8da87f911d3ea1b6af4b547974aef6366bec'},
-    {'libXcomposite-0.4.6.tar.gz': '3599dfcd96cd48d45e6aeb08578aa27636fa903f480f880c863622c2b352d076'},
-    {'libXrender-0.9.11.tar.gz': '6aec3ca02e4273a8cbabf811ff22106f641438eb194a12c0ae93c7e08474b667'},
-    {'libXcursor-1.2.1.tar.gz': '77f96b9ad0a3c422cfa826afabaf1e02b9bfbfc8908c5fa1a45094faad074b98'},
-    {'libXdamage-1.1.6.tar.gz': '2afcc139eb6eb926ffe344494b1fc023da25def42874496e6e6d3aa8acef8595'},
-    {'libfontenc-1.1.7.tar.gz': '5e5f210329823f08f97bfe9fd5b4105070c789bc5aef88ce01d86d8203d4aa9f'},
-    {'libXfont-1.5.4.tar.gz': '59be6eab53f7b0feb6b7933c11d67d076ae2c0fd8921229c703fc7a4e9a80d6e'},
-    {'libXfont2-2.0.6.tar.gz': 'a944df7b6837c8fa2067f6a5fc25d89b0acc4011cd0bc085106a03557fb502fc'},
-    {'libXft-2.3.8.tar.gz': '32e48fe2d844422e64809e4e99b9d8aed26c1b541a5acf837c5037b8d9f278a8'},
-    {'libXi-1.8.1.tar.gz': '3b5f47c223e4b63d7f7fe758886b8bf665b20a7edb6962c423892fd150e326ea'},
-    {'libXinerama-1.1.5.tar.gz': '2efa855cb42dc620eff3b77700d8655695e09aaa318f791f201fa60afa72b95c'},
-    {'libXrandr-1.5.3.tar.gz': '3ad316c1781fe2fe22574b819e81f0eff087a8560377f521ba932238b41b251f'},
-    {'libXres-1.2.2.tar.gz': '8abce597ced4a7ab89032aee91f6f784d9960adc772b2b59f17e515cd4127950'},
-    {'libXtst-1.2.4.tar.gz': '01366506aeb033f6dffca5326af85f670746b0cabbfd092aabefb046cf48c445'},
-    {'libXv-1.0.12.tar.gz': 'ce706619a970a580a0e35e9b5c98bdd2af243ac6494c65f44608a89a86100126'},
-    {'libXvMC-1.0.13.tar.gz': 'e630b4373af8c67a7c8f07ebe626a1269a613d262d1f737b57231a06f7c34b4e'},
-    {'libXxf86dga-1.1.6.tar.gz': '87c7482b1e29b4eeb415815641c4f69c00545a8138e1b73ff1f361f7d9c22ac4'},
-    {'libXxf86vm-1.1.5.tar.gz': 'f3f1c29fef8accb0adbd854900c03c6c42f1804f2bc1e4f3ad7b2e1f3b878128'},
-    {'libdmx-1.1.5.tar.gz': '070e82cc1daa1b21ee1339aef56a909eab04cbe7d430fabfbb01ecd21b2dd9f3'},
-    {'libxkbfile-1.1.2.tar.gz': 'd1a7e659bc7ae1aa1fc1ecced261c734df5ad5d86af1ef7a946be0e2d841e51d'},
-    {'libxshmfence-1.3.2.tar.gz': 'e93a85099604beb244ee756dcaf70e18b08701c1ca84c4de0126cd71bd6c8181'},
-    {'xcb-util-0.4.0.tar.gz': '0ed0934e2ef4ddff53fcc70fc64fb16fe766cd41ee00330312e20a985fd927a7'},
-    {'xcb-util-image-0.4.1.tar.gz': '0ebd4cf809043fdeb4f980d58cdcf2b527035018924f8c14da76d1c81001293b'},
-    {'xcb-util-keysyms-0.4.1.tar.gz': '1fa21c0cea3060caee7612b6577c1730da470b88cbdf846fa4e3e0ff78948e54'},
-    {'xcb-util-renderutil-0.3.10.tar.gz': 'e04143c48e1644c5e074243fa293d88f99005b3c50d1d54358954404e635128a'},
-    {'xcb-util-wm-0.4.2.tar.gz': 'dcecaaa535802fd57c84cceeff50c64efe7f2326bf752e16d2b77945649c8cd7'},
-    {'xcb-util-cursor-0.1.4.tar.gz': 'cc8608ebb695742b6cf84712be29b2b66aa5f6768039528794fca0fa283022bf'},
-    {'xkeyboard-config-2.38.tar.xz': '0690a91bab86b18868f3eee6d41e9ec4ce6894f655443d490a2184bfac56c872'},
-    {'printproto-1.0.5.tar.gz': 'e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc'},
-    {'libXp-1.0.4.tar.gz': '05e46af1ccb68f1752cca5879774a4fb9bf3b19fe088eb745034956e0c6fadba'},
-    {'xbitmaps-1.1.3.tar.gz': '93b433b7ff223c4685fdba583b4bd30f2706be2413a670021084422d85b0269d'},
-]
-
 
 preconfigopts = "if [ ! -f configure ]; then ./autogen.sh; fi && "
 


### PR DESCRIPTION
@Micket While the separate `checksums` is cleaner (and integrates better with `--inject-checksums`), I don't think we should block https://github.com/easybuilders/easybuild-easyconfigs/pull/18027 until https://github.com/easybuilders/easybuild-framework/issues/4289 is fixed, so let's proceed for now with the checksums included in `components`, as is the case for existing X11 easyconfigs?