### PR TITLE
Get build and tests to complete (ignoring failures)

### DIFF
--- a/easybuild/easyconfigs/l/librosa/librosa-0.10.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/l/librosa/librosa-0.10.1-foss-2023a.eb
@@ -1,0 +1,52 @@
+easyblock = 'PythonBundle'
+
+name = 'librosa'
+version = '0.10.1'
+
+homepage = 'https://librosa.org/'
+description = """Audio and music processing in Python"""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+builddependencies = [
+    ('matplotlib',  '3.7.2'),
+    ('poetry', '1.5.1'),  # build for soxr
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('Python-bundle-PyPI', '2023.06'),  # to get joblib
+    ('SciPy-bundle', '2023.07'),
+    ('scikit-learn', '1.3.1'),
+    ('FFmpeg', '6.0'),
+    ('numba', '0.58.1'),
+    ('libsndfile', '1.2.2'),
+]
+
+use_pip = True
+
+exts_list = [
+    ('soxr', '0.3.7', {
+        'preinstallopts': 'python -m build && ',
+        'checksums': ['436ddff00c6eb2c75b79c19cfdca7527b1e31b5fad738652f044045ba6258593'],
+    }),
+    ('audioread', '3.0.1', {
+        'checksums': ['ac5460a5498c48bdf2e8e767402583a4dcd13f4414d286f42ce4379e8b35066d'],
+    }),
+    ('soundfile', '0.12.1', {
+        'checksums': ['e8e1017b2cf1dda767aef19d2fd9ee5ebe07e050d430f77a0a7c66ba08b8cdae'],
+    }),
+    ('lazy_loader', '0.3', {
+        'checksums': ['3b68898e34f5b2a29daaaac172c6555512d0f32074f147e2254e4a6d9d838f37'],
+    }),
+    ('resampy', '0.4.3', {  # for tests
+        'checksums': ['a0d1c28398f0e55994b739650afef4e3974115edbe96cd4bb81968425e916e47'],
+    }),
+    (name, version, {
+        'checksums': ['832f7d150d6dd08ed2aa08c0567a4be58330635c32ddd2208de9bc91300802c7'],
+    }),
+]
+
+sanity_pip_check = True
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/NLTK/NLTK-3.8.1-foss-2023a.eb
+++ b/easybuild/easyconfigs/n/NLTK/NLTK-3.8.1-foss-2023a.eb
@@ -1,0 +1,55 @@
+easyblock = 'PythonBundle'
+
+name = 'NLTK'
+version = '3.8.1'
+
+homepage = 'https://www.nltk.org/'
+description = "NLTK is a leading platform for building Python programs to work with human language data."
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('SciPy-bundle', '2023.07'),
+    ('scikit-learn', '1.3.1'),
+    ('matplotlib', '3.7.2'),
+    ('tqdm', '4.66.1'),
+]
+
+local_nltk_data_install = []
+# Install NLTK data sets (7.4 GB)
+# local_nltk_data = '/path/to/database/nltk_data'
+# local_nltk_data_install = [
+#     "mkdir -p %s && NLTK_DATA=%s python -m nltk.downloader all" % (local_nltk_data, local_nltk_data)
+# ]
+# modextravars = {'NLTK_DATA': local_nltk_data}
+local_nltk_data = '/mimer/NOBACKUP/Datasets/NLTK'
+modextravars = {'NLTK_DATA': local_nltk_data}
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('regex', '2023.12.25', {
+        'checksums': ['29171aa128da69afdf4bde412d5bedc335f2ca8fcfe4489038577d05f16181e5'],
+    }),
+    ('python-crfsuite', '0.9.10', {
+        'modulename': 'pycrfsuite',
+        'checksums': ['f38524631e2b533341f10f2c77689270dc6ecd5985495dccf7aa37b1045bc2e5'],
+    }),
+    (name, version, {
+        'postinstallcmds': [],
+        'source_tmpl': '%(namelower)s-%(version)s.zip',
+        'use_pip_extras': 'corenlp,machine_learning,plot,tgrep',
+        'checksums': ['1834da3d0682cba4f2cede2f9aad6b0fafb6461ba451db0efb6f9c39798d64d3'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(namelower)s'],
+}
+
+sanity_check_commands = [('%(namelower)s', '--version')]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb
@@ -12,9 +12,13 @@ toolchain = {'name': 'foss', 'version': '2023a'}
 builddependencies = [
     ('CMake', '3.26.3'),
     ('RE2', '2023-08-01'),  # for torchtext
-    ('parameterized', '0.9.0'),
-    ('scikit-learn', '1.3.1'),
-    ('matplotlib', '3.7.2'),
+    ('parameterized', '0.9.0'),  # for torchtext and torchaudio tests
+    ('scikit-learn', '1.3.1'),  # for torchaudio and pytorch-ignite tests
+    ('scikit-image', '0.22.0'),  # for pytorch-ignite tests
+    ('dill', '0.3.7'),  # for pytorch-ignite tests
+    ('matplotlib', '3.7.2'),  # for pytorch-ignite tests
+    ('librosa', '0.10.1'),  # for torchaudio tests
+    ('NLTK', '3.8.1'),  # for torchtext tests
 ]
 
 dependencies = [
@@ -22,6 +26,7 @@ dependencies = [
     ('Python', '3.11.3'),
     ('PyTorch', version, versionsuffix),
     ('Pillow-SIMD', '9.5.0'),  # for torchvision
+    ('libjpeg-turbo', '2.1.5.1'),  # for torchvision
     ('SentencePiece', '0.2.0'),  # for torchtext
     ('tqdm', '4.66.1'),  # for torchtext
     ('double-conversion', '3.3.0'),  # for torchtext
@@ -45,19 +50,32 @@ exts_list = [
         'runtest': False,  # circular test requirements
     }),
     ('torchtext', '0.16.2', {
-        'patches': ['torchtext-0.14.1_use-system-libs.patch'],
+        'patches': [
+            'torchtext-0.14.1_use-system-libs.patch',
+            'torchtext-0.16.2_download-to-project-root.patch',
+        ],
         'source_urls': ['https://github.com/pytorch/text/archive'],
         'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
         'checksums': [
             {'torchtext-0.16.2.tar.gz': '6574b012804f65220329a2ad34a95c18e4df0d4cff2f862fb7862d57b374b013'},
             {'torchtext-0.14.1_use-system-libs.patch':
              '1366d10c4755b6003194f7313ca11d165a80a13d325bee9d669ea2b333d82536'},
+            {'torchtext-0.16.2_download-to-project-root.patch':
+             '9d5599a9983729cf1fc7ab2a2f65d1887f223f528e15662ba1b4a5e359c9686d'},
         ],
-        'runtest': 'pytest test/torchtext_unittest',
+        'runtest': (
+            'pytest test/torchtext_unittest'
+            ' -k "not test_vocab_from_raw_text_file"'  # segfaults
+            '" and not test_get_tokenizer_moses"'  # requires sacremoses
+            '" and not test_get_tokenizer_spacy"'  # requires spaCy
+        ),
         'testinstall': True,
     }),
+    ('pytest-mock', '3.11.1', {  # for torchvision tests
+        'checksums': ['7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f'],
+    }),
     ('torchvision', '0.16.2', {
-        'preinstallopts': 'WITH_CUDA=1',
+        'preinstallopts': 'WITH_CUDA=1 TORCHVISION_INCLUDE="$EBROOTLIBJPEGMINTURBO/include:$TORCHVISION_INCLUDE"',
         'installopts': '-v',
         'patches': ['torchvision-0.16.2_ffmpeg-6.0-fix.patch'],
         'source_urls': ['https://github.com/pytorch/vision/archive'],
@@ -67,13 +85,17 @@ exts_list = [
             {'torchvision-0.16.2_ffmpeg-6.0-fix.patch':
              'a49336e7bfa1c950e886852bff37a3ea2146ac7bda87241e3ffb31c5cb869cce'},
         ],
-        'runtest': 'pytest',
+        'runtest': (
+            'pytest'
+            ' -m "not xfail"'  # don't run tests that are expected that they might fail
+            ' -k "not test_frame_reading_mem_vs_file"'  # TODO this one hangs
+        ),
         'testinstall': True,
     }),
     ('torchaudio', '2.2.1', {
         'installopts': '--no-use-pep517 -v',
         'patches': ['torchaudio-2.2.1_use-external-sox.patch'],
-        'preinstallopts': ('rm -r third_party/{sox,ffmpeg/multi} &&'
+        'preinstallopts': ('rm -r third_party/{sox,ffmpeg/multi};'  # runs twice when testinstall
                            ' USE_CUDA=1 USE_OPENMP=1 USE_FFMPEG=1 FFMPEG_ROOT="$EBROOTFFMPEG"'),
         'source_urls': ['https://github.com/pytorch/audio/archive'],
         'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
@@ -83,17 +105,9 @@ exts_list = [
              'fc97b2bdf0ab16b9c4706bf2a31dd72d0ecb09e4af2f9c4a34e18fca8e0d165d'},
         ],
         'runtest': (
-            'pytest'  # ignored tests require librosa
-            ' --ignore=test/torchaudio_unittest/functional/librosa_compatibility_cpu_test.py'
-            ' --ignore=test/torchaudio_unittest/functional/librosa_compatibility_cuda_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/functional/librosa_compatibility_cpu_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/functional/librosa_compatibility_cuda_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/transforms/librosa_compatibility_cpu_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/transforms/librosa_compatibility_cuda_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/transforms/librosa_compatibility_cpu_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/transforms/librosa_compatibility_cuda_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/hifi_gan/hifi_gan_cpu_test.py'
-            ' --ignore=test/torchaudio_unittest/prototype/hifi_gan/hifi_gan_gpu_test.py'
+            'pytest'
+            ' -k "not TestProcessPoolExecutor"'  # TODO suspected to hang perhaps related to https://github.com/pytorch/audio/issues/1021
+            '" and not kaldi_io_test"'  # requires kaldi_io
             ' test/torchaudio_unittest/'
         ),
         'testinstall': True,
@@ -103,7 +117,16 @@ exts_list = [
         'source_urls': ['https://github.com/pytorch/ignite/archive'],
         'sources': [{'download_filename': 'v%(version)s.tar.gz', 'filename': '%(name)s-%(version)s.tar.gz'}],
         'checksums': ['bfe4b6f1cd96e78c021a65a0c51350cdb89d6ef5a8b9609638666ca95bae51d7'],
-        'runtest': 'pytest --ignore=tests/ignite/contrib',
+        'runtest': (
+            'pytest'
+            ' --ignore=tests/ignite/contrib/handlers/test_clearml_logger.py'  # requires clearml
+            ' --ignore=tests/ignite/metrics/gan/test_fid.py'  # requires pytorch_fid
+            '-k ' ' and '.join([  # TODO these tests hang
+                "not test__native_dist_model_create_no_dist_nccl"
+                "not test__native_dist_model_create_dist_gloo_2"
+                "not test__native_dist_model_create_dist_nccl_2"
+            ])
+        ),
         'testinstall': True,
     }),
     ('torch-tb-profiler', '0.4.3', {

--- a/easybuild/easyconfigs/p/PyTorch-bundle/torchtext-0.16.2_download-to-project-root.patch
+++ b/easybuild/easyconfigs/p/PyTorch-bundle/torchtext-0.16.2_download-to-project-root.patch
@@ -1,0 +1,35 @@
+TorchtextTestCase sets project root to test dir instead of project root. This
+patch makes sure the download ends up in the right place.
+
+Author: Viktor Rehnberg, vikren@chalmers.se (Chalmers University of Technology)
+
+
+--- text-0.16.2.old/test/torchtext_unittest/prototype/test_with_asset.py	2024-03-19 13:26:46.094164142 +0000
++++ text-0.16.2/test/torchtext_unittest/prototype/test_with_asset.py	2024-03-19 13:22:25.481657690 +0000
+@@ -201,7 +201,7 @@
+         self.assertEqual(dict(v2.get_stoi()), expected_stoi)
+ 
+     def test_builtin_pretrained_sentencepiece_processor(self) -> None:
+-        sp_model_path = download_from_url(PRETRAINED_SP_MODEL["text_unigram_25000"])
++        sp_model_path = download_from_url(PRETRAINED_SP_MODEL["text_unigram_25000"], root=os.path.join(self.project_root, ".data"))
+         spm_tokenizer = sentencepiece_tokenizer(sp_model_path)
+         _path = os.path.join(self.project_root, ".data", "text_unigram_25000.model")
+         os.remove(_path)
+@@ -209,7 +209,7 @@
+         ref_results = ["\u2581the", "\u2581pre", "trained", "\u2581sp", "m", "\u2581model", "\u2581names"]
+         self.assertEqual(spm_tokenizer(test_sample), ref_results)
+ 
+-        sp_model_path = download_from_url(PRETRAINED_SP_MODEL["text_bpe_25000"])
++        sp_model_path = download_from_url(PRETRAINED_SP_MODEL["text_bpe_25000"], root=os.path.join(self.project_root, ".data"))
+         spm_transform = sentencepiece_processor(sp_model_path)
+         _path = os.path.join(self.project_root, ".data", "text_bpe_25000.model")
+         os.remove(_path)
+@@ -223,7 +223,7 @@
+         example_strings = ["the pretrained spm model names"] * 64
+         ref_results = torch.tensor([[13, 1465, 12824, 304, 24935, 5771, 3776]] * 16, dtype=torch.long)
+ 
+-        sp_model_path = download_from_url(PRETRAINED_SP_MODEL["text_bpe_25000"])
++        sp_model_path = download_from_url(PRETRAINED_SP_MODEL["text_bpe_25000"], root=os.path.join(self.project_root, ".data"))
+         spm_processor = sentencepiece_processor(sp_model_path)
+         batch_fn = partial(_batch_func, spm_processor)
+ 


### PR DESCRIPTION
Changes:
 - Adds librosa, NLTK easyconfigs and adds these and more builddependencies for packages used in tests
 - Adds libjpeg-turbo as dependency and set TORCHVISION_INCLUDE envioronment variable to build torchvision with this
 - Adds patch for two tests to download pretrained models in a fixed location (not assuming that tests be run from test/ dir)
 - Adds pytest-mock as extension for torchvision test dependency
 - Make removing third_party dirs in preinstallcommand not needed to succeed for install to run (because testinstall makes this command be issued twice)
 - Ignore xfail tests in torchvision as well as tests that require extra builddependencies (kaldi_io, spacy, clearml, pytorch_fid)
 - Filter tests that are hinder completetion of tests:
    - torchtext: test_vocab_from_raw_text_file seg-faults
    - torchaudio: test_frame_reading_mem_vs_file hangs
    - torchvision: TestProcessPoolExecutor hangs
    - ignite: three tests that hang 
        - test__native_dist_model_create_no_dist_nccl 
        - test__native_dist_model_create_dist_gloo_2 
        - test__native_dist_model_create_dist_nccl_2

The filtered tests that hang or seg-fault should probably be investigated and there are some remaining tests that still fail as well.