### PR TITLE
Modifying the tagbot script directly

### DIFF
--- a/.github/workflows/tagbot.py
+++ b/.github/workflows/tagbot.py
@@ -40,6 +40,8 @@ def pr_ecs(pr_diff):
     return new_ecs, changed_ecs
 
 
+print("Teehee i'm doing evil stuff")
+
 GITHUB_API_URL = 'https://api.github.com'
 event_path = os.getenv('GITHUB_EVENT_PATH')
 token = os.getenv('GH_TOKEN')


### PR DESCRIPTION
This attempt to hack the script should achieve nothing, since the workflow won't actually use the script from the PR repo, but from the base ref.

It should add the "workflow" tag to highlight this change for the reviewer.