### PR TITLE
update SciPy-bundle 2025.06 to include numpy 2.3.1, scipy 1.16.0, numexpr 2.11.0, pandas 2.3.0 + add spin build dependency (required by numpy to run tests)

### DIFF
--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2025.06-gfbf-2025a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2025.06-gfbf-2025a.eb
@@ -19,6 +19,7 @@ builddependencies = [
     ('pkgconf', '2.3.0'),  # required by scipy
     ('Cython', '3.1.1'),  # required by numpy and scipy
     ('pybind11', '2.13.6'),  # required by scipy
+    ('spin', '0.14'),  # required for testing numpy
 ]
 
 dependencies = [
@@ -28,12 +29,12 @@ dependencies = [
 
 # order is important!
 exts_list = [
-    ('numpy', '2.2.6', {
+    ('numpy', '2.3.1', {
         'patches': [
             'numpy-1.22.3_disable-broken-override-test.patch',
         ],
         'checksums': [
-            {'numpy-2.2.6.tar.gz': 'e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd'},
+            {'numpy-2.3.1.tar.gz': '1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b'},
             {'numpy-1.22.3_disable-broken-override-test.patch':
              '9c589bb073b28b25ff45eb3c63c57966aa508dd8b318d0b885b6295271e4983c'},
         ],
@@ -53,7 +54,7 @@ exts_list = [
     ('versioneer', '0.29', {
         'checksums': ['5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731'],
     }),
-    ('scipy', '1.15.3', {
+    ('scipy', '1.16.0', {
         'enable_slow_tests': True,
         'ignore_test_result': False,
         'patches': [
@@ -62,7 +63,7 @@ exts_list = [
             'scipy-1.13.1_TestLinprogIPSparse.patch',
         ],
         'checksums': [
-            {'scipy-1.15.3.tar.gz': 'eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf'},
+            {'scipy-1.16.0.tar.gz': 'b5ef54021e832869c8cfb03bc3bf20366cbcd426e02a58e8a58d7584dfbb8f62'},
             {'scipy-1.11.1_disable-tests.patch': '906bfb03397d94882ccdc1b93bc2c8e854e0e060c2d107c83042992394e6a4af'},
             {'scipy-1.11.1_xfail-aarch64_test_maxiter_worsening.patch':
              '918c8e6fa8215d459126f267764c961bde729ea4a116c7f6287cddfdc58ffcea'},
@@ -70,8 +71,8 @@ exts_list = [
              '7213c2690b76c69f7e7103529cea3fa2098c05fbea556f04325fab9ca8c065f5'},
         ],
     }),
-    ('numexpr', '2.10.2', {
-        'checksums': ['b0aff6b48ebc99d2f54f27b5f73a58cb92fde650aeff1b397c71c8788b4fff1a'],
+    ('numexpr', '2.11.0', {
+        'checksums': ['75b2c01a4eda2e7c357bc67a3f5c3dd76506c15b5fd4dc42845ef2e182181bad'],
     }),
     ('bottleneck', '1.5.0', {
         'checksums': ['c860242cf20e69d5aab2ec3c5d6c8c2a15f19e4b25b28b8fca2c2a12cefae9d8'],
@@ -79,9 +80,9 @@ exts_list = [
     ('tzdata', '2025.2', {
         'checksums': ['b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9'],
     }),
-    ('pandas', '2.2.3', {
+    ('pandas', '2.3.0', {
         'preinstallopts': "export PANDAS_CI=0 && ",
-        'checksums': ['4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667'],
+        'checksums': ['34600ab34ebf1131a7613a260a61dbe8b62c188ec0ea4c296da7c9a06b004133'],
     }),
     ('mpmath', '1.3.0', {
         'checksums': ['7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f'],

--- a/easybuild/easyconfigs/s/spin/spin-0.14-GCCcore-14.2.0.eb
+++ b/easybuild/easyconfigs/s/spin/spin-0.14-GCCcore-14.2.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'spin'
+version = '0.14'
+
+homepage = 'https://github.com/scientific-python/spin'
+description = "Developer tool for scientific Python libraries"
+
+toolchain = {'name': 'GCCcore', 'version': '14.2.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['1a5f6ce53699ef58bf893970ecb9d7f8814a8ca08da5d26e1391fe2a9fa04bcc']
+
+dependencies = [
+    ('Python', '3.13.1'),
+    ('Python-bundle-PyPI', '2025.04'),
+]
+
+sanity_check_commands = [
+    # spin requires that a configuration file is in current directory, so create one
+    """echo '[tool.spin]' > pyproject.toml && echo 'package = "example_pkg"' >> pyproject.toml"""
+    "spin --version",
+]
+
+moduleclass = 'devel'


### PR DESCRIPTION
@Micket Update for https://github.com/easybuilders/easybuild-easyconfigs/pull/23023

The `numpy` part of this is working on top of https://github.com/easybuilders/easybuild-easyblocks/pull/3777 + https://github.com/easybuilders/easybuild-easyblocks/pull/3797, still testing the rest of it (but I would expect that part to work just fine)