### PR TITLE
remove patches no longer needed for scipy 1.16.0 + fix license issue in numexpr's pyproject.toml

### DIFF
--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2025.06-gfbf-2025a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2025.06-gfbf-2025a.eb
@@ -59,20 +59,16 @@ exts_list = [
         'ignore_test_result': False,
         'patches': [
             'scipy-1.11.1_disable-tests.patch',
-            'scipy-1.11.1_xfail-aarch64_test_maxiter_worsening.patch',
-            'scipy-1.13.1_TestLinprogIPSparse.patch',
         ],
         'checksums': [
             {'scipy-1.16.0.tar.gz': 'b5ef54021e832869c8cfb03bc3bf20366cbcd426e02a58e8a58d7584dfbb8f62'},
             {'scipy-1.11.1_disable-tests.patch': '906bfb03397d94882ccdc1b93bc2c8e854e0e060c2d107c83042992394e6a4af'},
-            {'scipy-1.11.1_xfail-aarch64_test_maxiter_worsening.patch':
-             '918c8e6fa8215d459126f267764c961bde729ea4a116c7f6287cddfdc58ffcea'},
-            {'scipy-1.13.1_TestLinprogIPSparse.patch':
-             '7213c2690b76c69f7e7103529cea3fa2098c05fbea556f04325fab9ca8c065f5'},
         ],
     }),
     ('numexpr', '2.11.0', {
         'checksums': ['75b2c01a4eda2e7c357bc67a3f5c3dd76506c15b5fd4dc42845ef2e182181bad'],
+        # workaround for: ValueError: invalid pyproject.toml config: project.license
+        'preinstallopts': "sed -i '/^license =/d' pyproject.toml && ",
     }),
     ('bottleneck', '1.5.0', {
         'checksums': ['c860242cf20e69d5aab2ec3c5d6c8c2a15f19e4b25b28b8fca2c2a12cefae9d8'],


### PR DESCRIPTION
@Micket fixes for https://github.com/easybuilders/easybuild-easyconfigs/pull/23023

With these added, the installation of `` works (on AMD Zen4).

The patches that deal with failing tests are no longer required on `aarch64` as far as I can tell, I'll confirm that with test reports in https://github.com/easybuilders/easybuild-easyconfigs/pull/23023