### PR TITLE
Fix broken mctc installation CMake files

### DIFF
--- a/easybuild/easyconfigs/m/mctc-lib/mctc-lib-0.5.0-GCC-14.3.0.eb
+++ b/easybuild/easyconfigs/m/mctc-lib/mctc-lib-0.5.0-GCC-14.3.0.eb
@@ -15,7 +15,13 @@ toolchainopts = {'pic': True}
 github_account = 'grimme-lab'
 source_urls = [GITHUB_SOURCE]
 sources = ['v%(version)s.tar.gz']
-checksums = ['ed0276618b9e1b41b5d228aedd4a1e07500472cfab5236179feb0cb55a0c8dc3']
+patches = ['mctc-lib-0.5.0_fix-install-template.patch']
+checksums = [
+    # v0.5.0.tar.gz
+    'ed0276618b9e1b41b5d228aedd4a1e07500472cfab5236179feb0cb55a0c8dc3',
+    # mctc-lib-0.5.0_fix-install-template.patch
+    '647c77ba4bd4ce78090c7f3dd60ccbc7d4263320ac53572e98fef7bc46135a20',
+]
 
 builddependencies = [
     ('binutils', '2.44'),

--- a/easybuild/easyconfigs/m/mctc-lib/mctc-lib-0.5.0_fix-install-template.patch
+++ b/easybuild/easyconfigs/m/mctc-lib/mctc-lib-0.5.0_fix-install-template.patch
@@ -1,0 +1,38 @@
+Fix error in installed CMake file, which leads to config failures later on
+when trying to use the package:
+
+```
+The link interface of target "mctc-lib::mctc-lib-lib" contains:
+
+    OpenMP::OpenMP_Fortran
+
+  but the target was not found.  Possible reasons include:
+```
+
+Instead of using a string, we should use the actual value.
+Tested manually with enabling and disabling OpenMP, which results in the
+desired effect.
+
+Author: Jan Andre Reuter (JSC)
+
+diff --color -Naur mctc-lib-0.5.0.orig/config/template.cmake mctc-lib-0.5.0/config/template.cmake
+--- mctc-lib-0.5.0.orig/config/template.cmake	2025-09-04 09:48:19.000000000 +0200
++++ mctc-lib-0.5.0/config/template.cmake	2025-10-30 09:59:50.463210351 +0100
+@@ -8,14 +8,14 @@
+ 
+   include(CMakeFindDependencyMacro)
+ 
+-  if(NOT TARGET "OpenMP::OpenMP_Fortran" AND "@PROJECT_NAME@_WITH_OpenMP")
++  if(NOT TARGET "OpenMP::OpenMP_Fortran" AND @PROJECT_NAME@_WITH_OpenMP)
+     find_dependency("OpenMP")
+   endif()
+ 
+-  if(NOT TARGET "toml-f::toml-f" AND "@PROJECT_NAME@_WITH_JSON")
++  if(NOT TARGET "toml-f::toml-f" AND @PROJECT_NAME@_WITH_JSON)
+     find_dependency("toml-f")
+   endif()
+-  if(NOT TARGET "jonquil::jonquil" AND "@PROJECT_NAME@_WITH_JSON")
++  if(NOT TARGET "jonquil::jonquil" AND @PROJECT_NAME@_WITH_JSON)
+     find_dependency("jonquil")
+   endif()
+ endif()


### PR DESCRIPTION
Installing `dftd4` still fails, but we get a bit forward at least. We'd need to port this to the other toolchains as well...

`dftd4` error:

```
/data/EasyBuild-develop/build/dftd4/3.7.0/gfbf-2025b/dftd4-3.7.0/src/dftd4/charge.f90:22:71:

   22 |       & write_ascii_model, write_ascii_properties, write_ascii_results, &
      |                                                                       1
Error: Symbol ‘get_coordination_number’ referenced at (1) not found in module ‘multicharge’
/data/EasyBuild-develop/build/dftd4/3.7.0/gfbf-2025b/dftd4-3.7.0/src/dftd4/charge.f90:23:32:

   23 |       & get_coordination_number, get_covalent_rad, get_lattice_points
      |                                1
Error: Symbol ‘get_covalent_rad’ referenced at (1) not found in module ‘multicharge’
/data/EasyBuild-develop/build/dftd4/3.7.0/gfbf-2025b/dftd4-3.7.0/src/dftd4/charge.f90:57:37:

   57 |    call new_eeq2019_model(mol, model)
      |                                     1
Error: Missing actual argument for argument ‘error’ at (1)
/data/EasyBuild-develop/build/dftd4/3.7.0/gfbf-2025b/dftd4-3.7.0/src/dftd4/charge.f90:65:10:

   65 |    rcov = get_covalent_rad(mol%num)
      |          1
Error: Function ‘get_covalent_rad’ at (1) has no IMPLICIT type
/data/EasyBuild-develop/build/dftd4/3.7.0/gfbf-2025b/dftd4-3.7.0/src/dftd4/charge.f90:66:80:

   66 |    call get_coordination_number(mol, trans, cutoff, rcov, cn, dcndr, dcndL, cut=cn_max)
      |                                                                                1
Error: Keyword argument requires explicit interface for procedure ‘get_coordination_number’ at (1)
/data/EasyBuild-develop/build/dftd4/3.7.0/gfbf-2025b/dftd4-3.7.0/src/dftd4/charge.f90:68:75:

   68 |    call model%solve(mol, cn, dcndr, dcndL, qvec=qvec, dqdr=dqdr, dqdL=dqdL)
      |                                                                           1
Error: Type mismatch in argument ‘error’ at (1); passed REAL(8) to TYPE(error_type)
/data/EasyBuild-develop/build/dftd4/3.7.0/gfbf-2025b/dftd4-3.7.0/src/dftd4/charge.f90:68:29:

   68 |    call model%solve(mol, cn, dcndr, dcndL, qvec=qvec, dqdr=dqdr, dqdL=dqdL)
      |                             1
Error: Rank mismatch in argument ‘cn’ at (1) (rank-1 and rank-3)
ninja: build stopped: subcommand failed.
```